### PR TITLE
only "in": "body" parameter added to body

### DIFF
--- a/R/operations.R
+++ b/R/operations.R
@@ -238,7 +238,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
     if(op_def$action == "post") {
       tmp_fun <- function() {
         x <- eval(param_values)
-        request_json <- get_message_body(x)
+        request_json <- get_message_body(op_def, x)
         result <- httr::POST(
           url = get_url(x),
           config = get_config(),
@@ -252,7 +252,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
     } else if(op_def$action == "put") {
       tmp_fun <- function() {
         x <- eval(param_values)
-        request_json <- get_message_body(x)
+        request_json <- get_message_body(op_def, x)
         result <- httr::PUT(
           url = get_url(x),
           config = get_config(),
@@ -310,7 +310,15 @@ get_operations <- function(api, .headers = NULL, path = NULL,
 #'
 #' @param x A list
 #' @keywords internal
-get_message_body <- function(x) {
+get_message_body <- function(op_def, x) {
+  parameters <- op_def$parameters
+  parameter_idx <- vapply(parameters, function(parameter) {
+      identical(parameter[["in"]], "body")
+  }, logical(1))
+  parameter_name <- parameters[[which(parameter_idx)]][["name"]]
+  x <- x[ names(x) %in% parameter_name ]
+  if (length(x))
+    x <- x[[1]]
   json <- jsonlite::toJSON(x, auto_unbox = TRUE, pretty = TRUE)
 
   if(getOption("rapiclient.log_request", default = FALSE)) {

--- a/tests/testthat/test_post.R
+++ b/tests/testthat/test_post.R
@@ -1,0 +1,43 @@
+context("POST get_message_body")
+
+test_that('only "in": "body" parameter is found', {
+    op_def <- list(parameters = list( list(`in` = "body", name = "param1") ))
+
+    expect <- structure("{}", class = "json")
+    x <- setNames(list(), character())
+    expect_identical(expect , get_message_body(op_def, x))
+    x <- list(param0 = "bad")
+    expect_identical(expect, get_message_body(op_def, x))
+
+    expect <- structure('"ok"', class = "json")
+    x <- list(param1 = "ok")
+    expect_identical(expect, get_message_body(op_def, x))
+    x <- list(param0 = "bad", param1 = "ok")
+    expect_identical(expect, get_message_body(op_def, x))
+})
+
+test_that("unboxing works", {
+    op_def <- list(parameters = list( list(`in` = "body", name = "param1") ))
+
+    expect <- structure('"ok"', class = "json")
+    x <- list(param1 = "ok")
+    expect_identical(expect, get_message_body(op_def, x))
+
+    expect <- structure('["ok"]', class = "json")
+    x <- list(param1 = I("ok"))
+    expect_identical(expect, get_message_body(op_def, x))
+
+    expect <- structure('["ok", "ok"]', class = "json")
+    x <- list(param1 = c("ok", "ok"))
+    expect_identical(expect, get_message_body(op_def, x))
+    x <- list(param1 = I(c("ok", "ok")))
+    expect_identical(expect, get_message_body(op_def, x))
+
+    expect <- structure('[\n  "ok"\n]', class = "json")
+    x <- list(param1 = list("ok"))
+    expect_identical(expect, get_message_body(op_def, x))
+
+    expect <- structure('[\n  "ok",\n  "ok"\n]', class = "json")
+    x <- list(param1 = list("ok", "ok"))
+    expect_identical(expect, get_message_body(op_def, x))
+})


### PR DESCRIPTION
- previous code inserted all parameters into body
- fails (as per spec.) if more than one "in": "body" parameter
- body contains JSON of `value`, rather than `list(arg = value)`