### PR TITLE
Small increments for some openapi3 support 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,5 @@ Imports:
   httr,
   yaml
 LazyData: TRUE
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Suggests: testthat

--- a/R/operations.R
+++ b/R/operations.R
@@ -239,6 +239,10 @@ get_operation_definitions <- function(api, path = NULL) {
 get_operations <- function(api, .headers = NULL, path = NULL,
                            handle_response = identity) {
 
+  if (!is.function(.headers)) {
+    .headers <- function() { .headers }
+  }
+
   operation_defs <- get_operation_definitions(api, path)
 
   param_values <- expression({
@@ -287,7 +291,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
           body = request_json,
           httr::content_type(consumes),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers)
+          httr::add_headers(.headers = .headers())
         )
         handle_response(result)
       }
@@ -304,7 +308,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
           body = request_json,
           httr::content_type(consumes),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers)
+          httr::add_headers(.headers = .headers())
         )
         handle_response(result)
       }
@@ -321,7 +325,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
           body = request_json,
           httr::content_type(consumes),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers)
+          httr::add_headers(.headers = .headers())
         )
         handle_response(result)
       }
@@ -333,7 +337,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
           config = get_config(),
           httr::content_type("application/json"),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers)
+          httr::add_headers(.headers = .headers())
         )
         handle_response(result)
       }
@@ -345,7 +349,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
           config = get_config(),
           httr::content_type("application/json"),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers)
+          httr::add_headers(.headers = .headers())
         )
         handle_response(result)
       }
@@ -357,7 +361,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
           config = get_config(),
           httr::content_type("application/json"),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers)
+          httr::add_headers(.headers = .headers())
         )
         handle_response(result)
       }

--- a/R/operations.R
+++ b/R/operations.R
@@ -10,7 +10,8 @@
 #' Create API object from Swagger specification
 #'
 #' @param url Api url (can be json or yaml format)
-#' @param config httr::config() curl options.
+#' @param config httr::config() curl options, provided either as an object or a
+#'   callback function
 #' @seealso See also \code{\link{get_operations}} and \code{\link{get_schemas}}
 #' @return API object
 #'
@@ -20,6 +21,19 @@
 #' \dontrun{
 #' # create operation and schema functions
 #' api <- get_api(api_url)
+#' operations <- get_operations(api)
+#' schemas <- get_schemas(api)
+#'
+#' # create operations with custom config callback
+#' config <- function(op_def) {
+#'    if (op_def$operationId == "createUser") {
+#'       httr::config(verbose = TRUE)
+#'    } else {
+#'       httr::config()
+#'    }
+#' }
+#'
+#' api <- get_api(api_url, config)
 #' operations <- get_operations(api)
 #' schemas <- get_schemas(api)
 #' }
@@ -46,9 +60,11 @@ get_api <- function(url, config = NULL) {
 
   # swagger element is required
   if (!is.null(api$swagger)) {
-    message("Swagger Specification version ", api$swagger)
+    # ok - nothing to do
+    #message("Swagger Specification version ", api$swagger)
   } else if (!is.null(api$openapi)) {
-    message("Openapi Specification version ", api$openapi)
+    # ok - nothing to do
+    #message("Openapi Specification version ", api$openapi)
   } else {
     warning("Missing Swagger and OpenApi Specification version")
   }
@@ -89,7 +105,7 @@ get_api <- function(url, config = NULL) {
   if (is.null(config)) {
     api$config <- NULL
   } else if (inherits(config, "request")) {
-    api$config <- function() { config }
+    api$config <- function(op_def) { config }
   } else if (is.function(config)) {
     api$config <- config
   } else {
@@ -216,7 +232,8 @@ get_operation_definitions <- function(api, path = NULL) {
 #'
 #' @param api API object (see \code{\link{get_api}})
 #' @param .headers Optional headers passed to httr functions. See
-#'   \code{\link[httr]{add_headers}} documentation
+#'   \code{\link[httr]{add_headers}} documentation. Can be provided either
+#'   as a vector of named headers or a callback function
 #' @param path (optional) filter by path from API specification
 #' @param handle_response (optional) A function with a single argument: httr
 #'   response
@@ -240,7 +257,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
                            handle_response = identity) {
 
   if (!is.function(.headers)) {
-    .headers <- function() { .headers }
+    .headers <- function(op_def) { .headers }
   }
 
   operation_defs <- get_operation_definitions(api, path)
@@ -287,11 +304,11 @@ get_operations <- function(api, .headers = NULL, path = NULL,
         )
         result <- httr::POST(
           url = get_url(x),
-          config = get_config(),
+          config = get_config(op_def),
           body = request_json,
           httr::content_type(consumes),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers())
+          httr::add_headers(.headers = .headers(op_def))
         )
         handle_response(result)
       }
@@ -304,11 +321,11 @@ get_operations <- function(api, .headers = NULL, path = NULL,
         )
         result <- httr::PATCH(
           url = get_url(x),
-          config = get_config(),
+          config = get_config(op_def),
           body = request_json,
           httr::content_type(consumes),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers())
+          httr::add_headers(.headers = .headers(op_def))
         )
         handle_response(result)
       }
@@ -321,11 +338,11 @@ get_operations <- function(api, .headers = NULL, path = NULL,
         )
         result <- httr::PUT(
           url = get_url(x),
-          config = get_config(),
+          config = get_config(op_def),
           body = request_json,
           httr::content_type(consumes),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers())
+          httr::add_headers(.headers = .headers(op_def))
         )
         handle_response(result)
       }
@@ -334,10 +351,10 @@ get_operations <- function(api, .headers = NULL, path = NULL,
         x <- eval(param_values)
         result <- httr::GET(
           url = get_url(x),
-          config = get_config(),
+          config = get_config(op_def),
           httr::content_type("application/json"),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers())
+          httr::add_headers(.headers = .headers(op_def))
         )
         handle_response(result)
       }
@@ -346,10 +363,10 @@ get_operations <- function(api, .headers = NULL, path = NULL,
         x <- eval(param_values)
         result <- httr::HEAD(
           url = get_url(x),
-          config = get_config(),
+          config = get_config(op_def),
           httr::content_type("application/json"),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers())
+          httr::add_headers(.headers = .headers(op_def))
         )
         handle_response(result)
       }
@@ -358,10 +375,10 @@ get_operations <- function(api, .headers = NULL, path = NULL,
         x <- eval(param_values)
         result <- httr::DELETE(
           url = get_url(x),
-          config = get_config(),
+          config = get_config(op_def),
           httr::content_type("application/json"),
           get_accept(op_def),
-          httr::add_headers(.headers = .headers())
+          httr::add_headers(.headers = .headers(op_def))
         )
         handle_response(result)
       }

--- a/R/operations.R
+++ b/R/operations.R
@@ -282,7 +282,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
       return(url)
     }
 
-    get_config <- function() {
+    get_config <- function(op_def) {
       api$config()
     }
 

--- a/R/operations.R
+++ b/R/operations.R
@@ -86,9 +86,15 @@ get_api <- function(url, config = NULL) {
     warning("There is no paths element in the API specification")
   }
 
-  if (!(is.null(config) || inherits(config, "request")))
-    stop("'config' must be NULL or an instance of httr::config()")
-  api$config <- config
+  if (is.null(config)) {
+    api$config <- NULL
+  } else if (inherits(config, "request")) {
+    api$config <- function() { config }
+  } else if (is.function(config)) {
+    api$config <- config
+  } else {
+    stop("'config' must be NULL, an instance of httr::config() or a function returning")
+  }
 
   class(api) <- c(.class_api, class(api))
   api
@@ -256,7 +262,7 @@ get_operations <- function(api, .headers = NULL, path = NULL,
     }
 
     get_config <- function() {
-      api$config
+      api$config()
     }
 
     get_accept <- function(op_def) {

--- a/R/operations.R
+++ b/R/operations.R
@@ -26,6 +26,7 @@
 #' @export
 get_api <- function(url, config = NULL) {
   api = NULL
+  #browser()
   api <- tryCatch({
       jsonlite::fromJSON(url, simplifyDataFrame = FALSE)
   }, error=function(x) NULL)
@@ -44,8 +45,12 @@ get_api <- function(url, config = NULL) {
       stop("'url' does not appear to be JSON or YAML")
 
   # swagger element is required
-  if (is.null(api$swagger)) {
-    warning("Missing Swagger Specification version")
+  if (!is.null(api$swagger)) {
+    message("Swagger Specification version ", api$swagger)
+  } else if (!is.null(api$openapi)) {
+    message("Openapi Specification version ", api$openapi)
+  } else {
+    warning("Missing Swagger and OpenApi Specification version")
   }
   # Info element is required
   if(is.null(api$info)) {

--- a/R/schema.R
+++ b/R/schema.R
@@ -1,5 +1,5 @@
 get_schema <- function(api, ref, compose_allOf = FALSE) {
-  if(!grepl("^#/definitions", ref )) {
+  if(!grepl("^#/definitions", ref ) && !grepl("^#/components", ref )) {
     ref <- paste0("#/definitions/", ref)
   }
   ref_pos <- strsplit(ref, "/")[[1]]

--- a/man/build_op_url.Rd
+++ b/man/build_op_url.Rd
@@ -4,14 +4,10 @@
 \alias{build_op_url}
 \title{Build operations url}
 \usage{
-build_op_url(api, scheme, host, base_path, op_def, par_values)
+build_op_url(api, op_def, par_values)
 }
 \arguments{
-\item{scheme}{http or https}
-
-\item{host}{host name with port (delimited by ":")}
-
-\item{base_path}{base path, defined in api specification}
+\item{api}{api object}
 
 \item{op_def}{a single operation definition}
 

--- a/man/get_api.Rd
+++ b/man/get_api.Rd
@@ -9,7 +9,8 @@ get_api(url, config = NULL)
 \arguments{
 \item{url}{Api url (can be json or yaml format)}
 
-\item{config}{httr::config() curl options.}
+\item{config}{httr::config() curl options, provided either as an object or a
+callback function}
 }
 \value{
 API object
@@ -21,6 +22,19 @@ Create API object from Swagger specification
 \dontrun{
 # create operation and schema functions
 api <- get_api(api_url)
+operations <- get_operations(api)
+schemas <- get_schemas(api)
+
+# create operations with custom config callback
+config <- function(op_def) {
+   if (op_def$operationId == "createUser") {
+      httr::config(verbose = TRUE)
+   } else {
+      httr::config()
+   }
+}
+
+api <- get_api(api_url, config)
 operations <- get_operations(api)
 schemas <- get_schemas(api)
 }

--- a/man/get_operations.Rd
+++ b/man/get_operations.Rd
@@ -4,14 +4,14 @@
 \alias{get_operations}
 \title{Get operations}
 \usage{
-get_operations(api, .headers = NULL, path = NULL,
-  handle_response = identity)
+get_operations(api, .headers = NULL, path = NULL, handle_response = identity)
 }
 \arguments{
 \item{api}{API object (see \code{\link{get_api}})}
 
 \item{.headers}{Optional headers passed to httr functions. See
-\code{\link[httr]{add_headers}} documentation}
+\code{\link[httr]{add_headers}} documentation. Can be provided either
+as a vector of named headers or a callback function}
 
 \item{path}{(optional) filter by path from API specification}
 

--- a/man/get_schema_graphviz_dot.Rd
+++ b/man/get_schema_graphviz_dot.Rd
@@ -4,8 +4,13 @@
 \alias{get_schema_graphviz_dot}
 \title{Get schema graphviz dot (experimental in this version)}
 \usage{
-get_schema_graphviz_dot(api, schema, schema_name = NULL,
-  rankdir = "LR", gv_attrs = "")
+get_schema_graphviz_dot(
+  api,
+  schema,
+  schema_name = NULL,
+  rankdir = "LR",
+  gv_attrs = ""
+)
 }
 \arguments{
 \item{api}{Api object}


### PR DESCRIPTION
I've been using rapiclient against some internal authenticated REST api's recently.

These APIs have necessitated a few small changes:

- allow the JSON to have `openapi` instead of `swagger` (was only a warning anyway)
- allow parameter definitions to come from `^#/components` as well as `^#/definitions`
- allow the `config` and `headers` to be callback functions rather than fixed objects

These changes still need a little documentation added (and maybe make them less verbose in their messaging too)

Are you interested in these? If you are then, I'll happily update the docs and tidy up this PR. If not, then no problem - we can run off a fork of this library - assuming that's OK with the license (currently it's not entirely obvious which open source model this is licensed under)

Thanks for all your work on this - it's a very useful library :)