### PR TITLE
Deal with parameters list() of length 0

### DIFF
--- a/R/operations.R
+++ b/R/operations.R
@@ -123,7 +123,10 @@ get_operation_definitions <- function(api, path = NULL) {
 
       # parameters can be defined on path level and overridden on operation
       # level
-      if(is.null(operation$parameters)) {
+      # 
+      # Note that parameters is often a list() rather than NULL, so deal
+      # that situation as well.
+      if(is.null(operation$parameters) || length(operation$parameters)==0) {
         operation$parameters <- api$paths[[path_name]]$parameters
       }
 


### PR DESCRIPTION
I am dealing with an API that, when parsed, results in a 
parameter list of length 0 at the action level rather than NULL. 
When this happens, no parameters are found. This small
check for length 0 list fixes that edge case and allows the 
path-level parameters to be picked up.