### PR TITLE
Handle accepts bigger than length 1

### DIFF
--- a/R/operations.R
+++ b/R/operations.R
@@ -260,6 +260,10 @@ get_operations <- function(api, .headers = NULL, path = NULL,
     get_accept <- function(op_def) {
       if (is.null(op_def$produces)) {
         httr::accept_json()
+      } else if(length(op_def$produces) > 1) {
+        for(each in op_def$produces) {
+          httr::accept(each)
+        }
       } else {
         httr::accept(op_def$produces)
       }


### PR DESCRIPTION
In R 4.1+, package fails even with petstore example:

```R
library(rapiclient)
pet_api <- get_api(url = "http://petstore.swagger.io/v2/swagger.json")
petoperations <- get_operations(pet_api)
petoperations$getPetById(1)
```
results in:

```
----------- FAILURE REPORT -------------- 
 --- failure: the condition has length > 1 ---
 --- srcref --- 
: 
 --- package (from environment) --- 
httr
 --- call from context --- 
httr::accept(op_def$produces)
 --- call from argument --- 
if (substr(type, 1, 1) == ".") {
    type <- mime::guess_type(type, empty = NULL)
}
 --- R stacktrace ---
where 1: httr::accept(op_def$produces)
where 2: get_accept(op_def)
where 3: named(list(...))
where 4: handle_url(handle, url, ...)
where 5: httr::GET(url = get_url(x), config = get_config(), httr::content_type("application/json"), 
    get_accept(op_def), httr::add_headers(.headers = .headers))
where 6: getpet(1)
where 7: httr::accept(op_def$produces)
where 8: get_accept(op_def)
where 9: named(list(...))
where 10: handle_url(handle, url, ...)
where 11: httr::GET(url = get_url(x), config = get_config(), httr::content_type("application/json"), 
    get_accept(op_def), httr::add_headers(.headers = .headers))
where 12: petoperations$getPetById(1)

 --- value of length: 2 type: logical ---
[1] FALSE FALSE
 --- function from context --- 
function (type) 
{
    if (substr(type, 1, 1) == ".") {
        type <- mime::guess_type(type, empty = NULL)
    }
    add_headers(Accept = type)
}
<bytecode: 0x563d5dde08c8>
<environment: namespace:httr>
 --- function search by body ---
Function accept in namespace httr has this body.
 ----------- END OF FAILURE REPORT -------------- 
Error in if (substr(type, 1, 1) == ".") { : the condition has length > 1
```

This quick PR aims to add handling of multiple accept headers, assuming I properly understood how `httr::accept` works (i.e. assuming it won't just ignore all but the last one)