### PR TITLE
Combine parameters from path + operation

### DIFF
--- a/R/operations.R
+++ b/R/operations.R
@@ -129,6 +129,9 @@ get_operation_definitions <- function(api, path = NULL) {
       if(is.null(operation$parameters) || length(operation$parameters)==0) {
         operation$parameters <- api$paths[[path_name]]$parameters
       }
+      else if(!is.null(api$paths[[path_name]]$parameters) && length(api$paths[[path_name]]$parameters)>0) {
+        operation$parameters <- c(operation$parameters, api$paths[[path_name]]$parameters)
+      }
 
       # get referenced parameters (when parameter has $ref = #/parameters/...)
       operation$parameters <-


### PR DESCRIPTION
For the kubernetes api (https://gist.githubusercontent.com/almahmoud/19c45f0debf54abc1cb8eb779a2e823b/raw/90a18dc5c2ead172767b0013f12902ffc39fe16d/swagger.json) there are sets of parameters per operation, but also parameters that should be applied for all operations at a certain API path.
This PR makes it so that parameters for the path are combined with operation-specific parameters.