### PR TITLE
Add explicit type and pass httr config to api schema init

### DIFF
--- a/man/get_api.Rd
+++ b/man/get_api.Rd
@@ -4,7 +4,7 @@
 \alias{get_api}
 \title{Get API}
 \usage{
-get_api(url, config = NULL)
+get_api(url, config = NULL, type = NULL)
 }
 \arguments{
 \item{url}{Api url (can be json or yaml format)}


### PR DESCRIPTION
- Add ability to explicitly set desired type (json vs yaml) to `get_api` method, making it work for endpoints even if the URL does not end with descriptive extension. Defaults to extension sniffing if not set, so backwards compatible with no change.
- Use httr to get URL, passing config to the request (allowing for eg: adding token to get API schema when auth is needed), and parsing JSON/YAML afterwards.